### PR TITLE
Adding logging to constructFromCached result

### DIFF
--- a/src/Injector/Injector.ts
+++ b/src/Injector/Injector.ts
@@ -422,18 +422,23 @@ export class Injector {
   }
 
   private _constructFromCachedResults<T = any>(factory: IFactory, results): IInstance<T> {
-    if (isFunctionalFactory(factory)) {
-      const { factory: Factory } = factory;
-      if (Array.isArray(results)) {
-        return Factory(...results);
+    try {
+      if (isFunctionalFactory(factory)) {
+        const { factory: Factory } = factory;
+        if (Array.isArray(results)) {
+          return Factory(...results);
+        }
+        return Factory(results);
+      } else if (isConstructorFactory(factory)) {
+        const { factory: Factory } = factory;
+        if (Array.isArray(results)) {
+          return new Factory(...results);
+        }
+        return new Factory(results);
       }
-      return Factory(results);
-    } else if (isConstructorFactory(factory)) {
-      const { factory: Factory } = factory;
-      if (Array.isArray(results)) {
-        return new Factory(...results);
-      }
-      return new Factory(results);
+    } catch (e) {
+      console.error('Error instantiating', JSON.stringify(factory));
+      throw e;
     }
   }
 


### PR DESCRIPTION
Was getting a non-descript error
```
TypeError: Factory is not a constructor
    at Injector._constructFromCachedResults (node_modules/boxed-injector/src/Injector/Injector.ts:458:7)
    at Injector.get (node_modules/boxed-injector/src/Injector/Injector.ts:400:25)
```
And I thought having more logging as to what was trying to be
be instantiated at the time would be better